### PR TITLE
add cv:: prefix to constants

### DIFF
--- a/src/CLD.cpp
+++ b/src/CLD.cpp
@@ -51,7 +51,7 @@ void CLD::init(const cv::Size s)
 
 void CLD::readSrc(const std::string file)
 {
-    originalImg = cv::imread(file, CV_LOAD_IMAGE_GRAYSCALE);
+    originalImg = cv::imread(file, cv::IMREAD_GRAYSCALE);
 
     result = cv::Mat::zeros(cv::Size(originalImg.cols, originalImg.rows), CV_8UC1);
     DoG    = cv::Mat::zeros(cv::Size(originalImg.cols, originalImg.rows), CV_32FC1);

--- a/src/ETF.cpp
+++ b/src/ETF.cpp
@@ -30,9 +30,9 @@ ETF::ETF(const cv::Size s)
 void ETF::initial_ETF(const std::string file, const cv::Size s)
 {
     // Resizing Mat
-    cv::resize(flowField, flowField, s, 0, 0, CV_INTER_LINEAR);
-    cv::resize(refinedETF, refinedETF, s, 0, 0, CV_INTER_LINEAR);
-    cv::resize(gradientMag, gradientMag, s, 0, 0, CV_INTER_LINEAR);
+    cv::resize(flowField, flowField, s, 0, 0, cv::INTER_LINEAR);
+    cv::resize(refinedETF, refinedETF, s, 0, 0, cv::INTER_LINEAR);
+    cv::resize(gradientMag, gradientMag, s, 0, 0, cv::INTER_LINEAR);
 
     cv::Mat src = cv::imread(file, 1);
     cv::Mat src_n;

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
         cld.genCLD();
     }
 
-    cv::cvtColor(cld.result, cld.result, CV_GRAY2RGB);
+    cv::cvtColor(cld.result, cld.result, cv::COLOR_GRAY2RGB);
     cv::imwrite(output_path, cld.result);
     std::cout << "Result image save at " << output_path << std::endl;
 
@@ -92,13 +92,13 @@ int main(int argc, char *argv[])
         // Generate flow-field visualization
         cv::Mat vis_etf = postprocess::visualizeETF(cld.etf.flowField);
         vis_etf.convertTo(vis_etf, CV_8UC1, 255);
-        cv::cvtColor(vis_etf, vis_etf, CV_GRAY2BGR);
+        cv::cvtColor(vis_etf, vis_etf, cv::COLOR_GRAY2BGR);
         cv::imwrite("visualize-etf.jpg", vis_etf);
 
         // Generate flow-field arrow direction visualization
         cv::Mat vis_flow = postprocess::visualizeFlowfield(cld.etf.flowField);
         vis_flow.convertTo(vis_flow, CV_8UC3, 255);
-        cv::cvtColor(vis_flow, vis_flow, CV_RGB2BGR);
+        cv::cvtColor(vis_flow, vis_flow, cv::COLOR_RGB2BGR);
         cv::imwrite("arrow-etf.jpg", vis_flow);
 
         // Generate Anti-alias coherent line drawing

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -252,7 +252,7 @@ void MyFrame::OnSaveResult(wxCommandEvent &event)
     }
 
     cv::Mat res = drawPane->image().clone();
-    cv::cvtColor(drawPane->image(), res, CV_BGR2RGB);
+    cv::cvtColor(drawPane->image(), res, cv::COLOR_BGR2RGB);
     cv::imwrite((const char *)saveFileDialog.GetPath().mb_str(), res);
 }
 
@@ -436,23 +436,23 @@ DrawPane::DrawPane(wxPanel *parent, cv::Size s)
 void DrawPane::render()
 {
     dis_ = cld_.originalImg.clone();
-    cv::cvtColor(dis_, dis_, CV_GRAY2BGR);
+    cv::cvtColor(dis_, dis_, cv::COLOR_GRAY2BGR);
 
     if (mode_ == MODE_ETF) {
         dis_ = postprocess::visualizeETF(cld_.etf.flowField);
         dis_.convertTo(dis_, CV_8UC1, 255);
-        cv::cvtColor(dis_, dis_, CV_GRAY2BGR);
+        cv::cvtColor(dis_, dis_, cv::COLOR_GRAY2BGR);
     } else if (mode_ == MODE_ETF_DEBUG) {
         dis_ = postprocess::visualizeFlowfield(cld_.etf.flowField);
         dis_.convertTo(dis_, CV_8UC3, 255);
-        cv::cvtColor(dis_, dis_, CV_RGB2BGR);
+        cv::cvtColor(dis_, dis_, cv::COLOR_RGB2BGR);
     } else if (mode_ == MODE_CLD) {
         dis_ = cld_.result.clone();
-        cv::cvtColor(dis_, dis_, CV_GRAY2BGR);
+        cv::cvtColor(dis_, dis_, cv::COLOR_GRAY2BGR);
     } else if (mode_ == MODE_ANTI_ALIASING) {
         dis_ = cld_.result.clone();
         dis_ = postprocess::antiAlias(dis_);
-        cv::cvtColor(dis_, dis_, CV_GRAY2BGR);
+        cv::cvtColor(dis_, dis_, cv::COLOR_GRAY2BGR);
     }
 
     wxBitmap bmp(wxImage(dis_.cols, dis_.rows, dis_.data, true));


### PR DESCRIPTION
These changes were required for me to build against Opencv 4.5.1. Without these changes I got the following errors:

```console
$ ./build.sh -c
/usr/bin/nproc
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenCV: /usr (found version "4.2.0") 
-- Found wxWidgets: -L/usr/lib/x86_64-linux-gnu;-pthread;;;-lwx_gtk3u_xrc-3.0;-lwx_gtk3u_html-3.0;-lwx_gtk3u_qa-3.0;-lwx_gtk3u_adv-3.0;-lwx_gtk3u_core-3.0;-lwx_baseu_xml-3.0;-lwx_baseu_net-3.0;-lwx_baseu-3.0 (found version "3.0.4") 
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0")  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/kyle/Coherent-Line-Drawing/build
Scanning dependencies of target cld
Scanning dependencies of target Coherent-Line-Drawing
[  9%] Building CXX object CMakeFiles/cld.dir/src/cmd.cpp.o
[ 18%] Building CXX object CMakeFiles/Coherent-Line-Drawing.dir/src/main.cpp.o
/home/kyle/Coherent-Line-Drawing/src/cmd.cpp: In function ‘int main(int, char**)’:
/home/kyle/Coherent-Line-Drawing/src/cmd.cpp:87:42: error: ‘CV_GRAY2RGB’ was not declared in this scope
   87 |     cv::cvtColor(cld.result, cld.result, CV_GRAY2RGB);
      |                                          ^~~~~~~~~~~
/home/kyle/Coherent-Line-Drawing/src/cmd.cpp:97:40: error: ‘CV_GRAY2BGR’ was not declared in this scope
   97 |         cv::cvtColor(vis_etf, vis_etf, CV_GRAY2BGR);
      |                                        ^~~~~~~~~~~
make[2]: *** [CMakeFiles/cld.dir/build.make:63: CMakeFiles/cld.dir/src/cmd.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/cld.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 27%] Building CXX object CMakeFiles/Coherent-Line-Drawing.dir/src/ETF.cpp.o
[ 36%] Building CXX object CMakeFiles/Coherent-Line-Drawing.dir/src/CLD.cpp.o
/home/kyle/Coherent-Line-Drawing/src/ETF.cpp: In member function ‘void ETF::initial_ETF(std::string, cv::Size)’:
/home/kyle/Coherent-Line-Drawing/src/ETF.cpp:33:47: error: ‘CV_INTER_LINEAR’ was not declared in this scope
   33 |     cv::resize(flowField, flowField, s, 0, 0, CV_INTER_LINEAR);
      |                                               ^~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/Coherent-Line-Drawing.dir/build.make:76: CMakeFiles/Coherent-Line-Drawing.dir/src/ETF.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/home/kyle/Coherent-Line-Drawing/src/CLD.cpp: In member function ‘void CLD::readSrc(std::string)’:
/home/kyle/Coherent-Line-Drawing/src/CLD.cpp:52:36: error: ‘CV_LOAD_IMAGE_GRAYSCALE’ was not declared in this scope
   52 |     originalImg = cv::imread(file, CV_LOAD_IMAGE_GRAYSCALE);
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/Coherent-Line-Drawing.dir/build.make:89: CMakeFiles/Coherent-Line-Drawing.dir/src/CLD.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:105: CMakeFiles/Coherent-Line-Drawing.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```