### PR TITLE
ci: fix pipeline on ubuntu-latest (Ubuntu 24.04)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: apt update
       run: sudo apt-get update
     - name: apt
-      run: sudo apt-get install g++ cmake libopencv-dev libwxgtk3.0-dev libboost-all-dev clang-format colordiff lcov
+      run: sudo apt-get install g++ cmake libopencv-dev libwxgtk3.2-dev libboost-all-dev clang-format colordiff lcov
     - name: lint
       run: bash linter.sh
     - name: build

--- a/src/CLD.cpp
+++ b/src/CLD.cpp
@@ -172,7 +172,7 @@ void CLD::gradientDoG(const cv::Mat &src, cv::Mat &dst, const double rho, const 
 
                 const float value = src.at<float>((int)round(row), (int)round(col));
 
-                const int gau_idx         = abs(step);
+                const int gau_idx = abs(step);
                 // The sigma_s support is wider than sigma_c's; beyond gau_c's
                 // support the center gaussian contributes nothing.
                 const double gau_c_weight = gau_idx < static_cast<int>(gau_c.size()) ? gau_c[gau_idx] : 0.0;

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
+set -e
 
 rm -rf .coverage coverage.info
 
 time ./build/cld --src ./data/fingerprint.jpg -o output.jpg --ETF_iter 3 --CLD_iter 8 --debug_img
-echo '10459bb86077235db3f85fe64d25f2d8 output.jpg' | md5sum -c - 
-echo '3ea95ae0f6f92478af7fbf97e96b2763 anti-alias.jpg' | md5sum -c - 
-echo '1a68133901751c29efe4febec29d014e visualize-etf.jpg' | md5sum -c - 
-echo '365b29b4d15520b5c92eb78bc6c236b8 arrow-etf.jpg' | md5sum -c - 
+echo '92757f83506131ade0ac4e9c84f755f4 output.jpg' | md5sum -c -
+echo '4a1cd86bd6a52f7abe6fa594ac5b5bc6 anti-alias.jpg' | md5sum -c -
+echo 'a55c4e14b375e6e0222d123d2de4db21 visualize-etf.jpg' | md5sum -c -
+echo '365b29b4d15520b5c92eb78bc6c236b8 arrow-etf.jpg' | md5sum -c -
 
 if ! which lcov; then
     exit 0


### PR DESCRIPTION
- Replace libwxgtk3.0-dev with libwxgtk3.2-dev, as wxWidgets 3.0
  has no installation candidate on Ubuntu 24.04 runners
- Update actions/checkout from deprecated v2 to v4
- Reformat src/CLD.cpp to satisfy clang-format 18
- Update expected image hashes in test.sh for OpenCV 4.6 output
  and add set -e so hash mismatches actually fail the test step